### PR TITLE
Added spaces so that the title correctly render

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#adapt-contrib-gmcq
+# adapt-contrib-gmcq
 
 A skeleton for building question components
 
-##Installation
+## Installation
 
 
 First, be sure to install the [Adapt Command Line Interface](https://github.com/adaptlearning/adapt-cli), then from the command line run:-
@@ -13,40 +13,40 @@ This component can also be installed by adding the component to the adapt.json f
 
         "adapt-contrib-question": "*"
 
-##Usage
+## Usage
 
 To Be Updated
 
-##Settings overview
+## Settings overview
  
 An complete example of this components settings can be found in the [example.json](https://github.com/adaptlearning/adapt-contrib-gmcq/blob/master/example.json) file. A description of the core settings can be found at: [Core model attributes](https://github.com/adaptlearning/adapt_framework/wiki/Core-model-attributes)
 
 Further settings for this component are:
 
-####_component
+#### _component
 
 This value must be: `question`
 
-####_classes
+#### _classes
 
 You can use this setting to add custom classes to your template and LESS file.
 
-####_layout
+#### _layout
 
 This defines the position of the component in the block. Values can be `full`, `left` or `right`. 
 
-####_attempts
+#### _attempts
 
 Default: `1`
 
 Specifies the number of attempts for this question.
 
-####_items
+#### _items
 
 ##Limitations
  
 To be completed.
 
-##Browser spec
+## Browser spec
 
 This component has been tested to the standard Adapt browser specification.


### PR DESCRIPTION
Markdown must have had a change recently as I've noticed loads of titles showing like this.